### PR TITLE
Specify serviceAccountName to inherit correct permissions

### DIFF
--- a/templates/server.yaml
+++ b/templates/server.yaml
@@ -13,6 +13,7 @@ spec:
         {{- include "kepler.selectorLabels" . | nindent 8 }}
     spec:
       hostNetwork: true
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:
       - name: kepler-exporter
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
Kepler exporter Pods inherit the default SA which doesn't have the necessary permissions to retrieve metrics etc.

This commit specifies the serviceAccountName and ties it to the one that's created so that the right permissions are in place.