### PR TITLE
Use DirectoryOrCreate type for lib-modules and add usr-src by default

### DIFF
--- a/templates/server.yaml
+++ b/templates/server.yaml
@@ -13,6 +13,7 @@ spec:
         {{- include "kepler.selectorLabels" . | nindent 8 }}
     spec:
       hostNetwork: true
+      serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:
       - name: kepler-exporter
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/templates/server.yaml
+++ b/templates/server.yaml
@@ -13,7 +13,6 @@ spec:
         {{- include "kepler.selectorLabels" . | nindent 8 }}
     spec:
       hostNetwork: true
-      serviceAccountName: {{ .Values.serviceAccount.name }}
       containers:
       - name: kepler-exporter
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -52,6 +51,8 @@ spec:
           name: tracing
         - mountPath: /proc
           name: proc
+        - mountPath: /usr/src
+          name: usr-src
         env:
         - name: NODE_NAME
           valueFrom:
@@ -63,7 +64,7 @@ spec:
       - name: lib-modules
         hostPath:
           path: /lib/modules
-          type: Directory
+          type: DirectoryOrCreate
       - name: tracing
         hostPath:
           path: /sys
@@ -71,4 +72,8 @@ spec:
       - name: proc
         hostPath:
           path: /proc
+          type: Directory
+      - name: usr-src
+        hostPath:
+          path: /usr/src
           type: Directory


### PR DESCRIPTION
Use DirectoryOrCreate type for lib-modules volume to be sure that the /lib/modules folder will be there, and add usr-src volume to make sure the kernel headers will be visible after binded-mounted, following its symlink, that is on lib-modules but point to usr-src.