### PR TITLE
Add serviceMonitor manifest

### DIFF
--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -6,12 +6,16 @@ metadata:
   namespace: {{ .Values.global.namespace }}
   labels:
     {{- include "kepler.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  clusterIP: None
+  type: {{ .Values.service.type }}
   ports:
-  - port: {{ .Values.service.port }}
-    targetPort: http
-    protocol: TCP
-    name: http
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
   selector:
     {{- include "kepler.selectorLabels" . | nindent 4 }}

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "kepler.fullname" . }}-prometheus-exporter
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels:
+    {{- include "kepler.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  jobLabel: app.kubernetes.io/name
+  endpoints:
+    - port: {{ .Values.service.portName }}
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      path: /metrics
+      scheme: http
+      relabelings:
+        - action: replace
+          regex: (.*)
+          replacement: $1
+          sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: instance
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "kepler.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   jobLabel: app.kubernetes.io/name
   endpoints:
-    - port: {{ .Values.service.portName }}
+    - port: http
       {{- with .Values.serviceMonitor.interval }}
       interval: {{ . }}
       {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -30,6 +30,7 @@ securityContext:
   privileged: true
 
 service:
+  annotations: {}
   type: ClusterIP
   port: 9102
 

--- a/values.yaml
+++ b/values.yaml
@@ -48,3 +48,10 @@ tolerations:
     key: node-role.kubernetes.io/master
 
 affinity: {}
+
+serviceMonitor:
+  enabled: true
+  namespace: ""
+  interval: 30s
+  scrapeTimeout: 5s
+  labels: {}

--- a/values.yaml
+++ b/values.yaml
@@ -50,7 +50,7 @@ tolerations:
 affinity: {}
 
 serviceMonitor:
-  enabled: true
+  enabled: false
   namespace: ""
   interval: 30s
   scrapeTimeout: 5s


### PR DESCRIPTION
Hi,
this PR:
- add the possiblity to deploy a `serviceMonitor`
- add annotation for `service`
- add type for `service`

Thanks