### PR TITLE
Remove global.namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # kepler-helm-chart
 
-This repository is for the Helm chart for Kepler.  We are using gh-pages branch to host and index the chart.  When modifying the chart please bump the version in the [Chart.yaml](/chart/kepler/Chart.yaml) file.
+This repository is for the Helm chart for Kepler.  We are using `gh-pages` branch to host and index the chart.  When modifying the chart please bump the version in the [Chart.yaml](/chart/kepler/Chart.yaml) file.
 
 The chart is accessible using the following commands:
 
@@ -19,11 +19,11 @@ helm search repo kepler
 If you would like to test and look at the manifest files before deploying you can run:
 
 ```bash
-helm install kepler kepler/kepler --dry-run --devel
+helm install kepler kepler/kepler --namespace kepler --create-namespace --dry-run --devel
 ```
 
 Then to install run the following:
 
 ```bash
-helm install kepler kepler/kepler
+helm install kepler kepler/kepler --namespace kepler --create-namespace
 ```

--- a/chart/kepler/Chart.yaml
+++ b/chart/kepler/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kepler
 description: A Helm chart for kepler
 type: application
-version: 0.3.1
-appVersion: "1.16.0"
+version: 0.3.2
+appVersion: 0.4.0
 home: https://sustainable-computing.io/html/index.html
 sources:
   - https://github.com/sustainable-computing-io/kepler

--- a/chart/kepler/templates/rolebinding.yaml
+++ b/chart/kepler/templates/rolebinding.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "kepler.name" . }}-clusterrole
-  namespace: {{ .Values.global.namespace }}
 rules:
 - apiGroups: [""]
   resources:
@@ -20,7 +19,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "kepler.name" . }}-clusterrole-binding
-  namespace: {{ .Values.global.namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ .Chart.Name }}-clusterrole

--- a/chart/kepler/templates/rolebinding.yaml
+++ b/chart/kepler/templates/rolebinding.yaml
@@ -26,4 +26,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "kepler.serviceAccountName" . }}
-  namespace: {{ .Values.global.namespace }}
+  namespace: {{ .Release.Namespace }}

--- a/chart/kepler/templates/server.yaml
+++ b/chart/kepler/templates/server.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "kepler.name" . }}
-  namespace: {{ .Values.global.namespace }}
   labels:
     {{- include "kepler.labels" . | nindent 4 }}
 spec:

--- a/chart/kepler/templates/service.yaml
+++ b/chart/kepler/templates/service.yaml
@@ -3,7 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kepler.name" . }}
-  namespace: {{ .Values.global.namespace }}
   labels:
     {{- include "kepler.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/chart/kepler/templates/serviceaccount.yaml
+++ b/chart/kepler/templates/serviceaccount.yaml
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kepler.serviceAccountName" . }}
-  namespace: {{ .Values.global.namespace }}
   labels:
     {{- include "kepler.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/chart/kepler/values.yaml
+++ b/chart/kepler/values.yaml
@@ -1,7 +1,4 @@
 ---
-global:
-  namespace: "kepler"
-
 image:
   repository: quay.io/sustainable_computing_io/kepler
   pullPolicy: Always


### PR DESCRIPTION
Hi,
I would like to remove `global.namespace` option in `values.yaml` as it is quite confusing.

`helm` options allow to select/create the namespace (`--namespace ...`/`--create-namespace`).

Thanks 