### PR TITLE
set `appVersion`to `v0.4.11`

### DIFF
--- a/chart/kepler/Chart.yaml
+++ b/chart/kepler/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kepler
 description: A Helm chart for kepler
 type: application
-version: 0.3.5
-appVersion: latest
+version: 0.3.6
+appVersion: v0.4.11-23-g2b59dbd-linux-amd64
 home: https://sustainable-computing.io/html/index.html
 sources:
   - https://github.com/sustainable-computing-io/kepler


### PR DESCRIPTION
Hi,
until we have a clear outcome from [#640](https://github.com/sustainable-computing-io/kepler/issues/640), I would suggest to use the `v0.4.11-23-g2b59dbd-linux-amd64` container image.
`latest` can the result of PR, therefore it is not a release and it is not predictable.

Thanks