### PR TITLE
feat: add signing capability for helm chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,25 @@ jobs:
         with:
           version: latest
 
+      - name: Prepare keys for signing
+        env:
+          SIGNING_KEY_BASE64: ${{ secrets.HELM_SIGNING_PRIVATE_KEY }}
+          SIGNING_KEY_PASSPHRASE_BASE64: ${{ secrets.HELM_SIGNING_PRIVATE_KEY_PASSPHRASE }}
+          KEY_PATH: ".gpg-dir"
+          SIGNING_KEY_PATH: ".gpg-dir/secring.gpg"
+          SIGNING_KEY_PASSPHRASE_PATH: ".gpg-dir/passphrase"
+        run: |
+          mkdir "$KEY_PATH"
+          base64 -d <<< "$SIGNING_KEY_BASE64" > "$SIGNING_KEY_PATH"
+          base64 -d <<< "$SIGNING_KEY_PASSPHRASE_BASE64" > "$SIGNING_KEY_PASSPHRASE_PATH"
+          echo "CR_PASSPHRASE_FILE=$SIGNING_KEY_PASSPHRASE_PATH" >> "$GITHUB_ENV"
+          echo "CR_KEYRING=$SIGNING_KEY_PATH" >> "$GITHUB_ENV"
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@be16258da8010256c6e82849661221415f031968 # v1.5.0
         with:
           charts_dir: chart
+          config: cr.yaml
           charts_repo_url: https://sustainable-computing-io.github.io/kepler-helm-chart
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,5 @@ jobs:
         with:
           charts_dir: chart
           config: cr.yaml
-          charts_repo_url: https://sustainable-computing-io.github.io/kepler-helm-chart
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/kepler)](https://artifacthub.io/packages/search?repo=kepler) ![GitHub](https://img.shields.io/github/license/sustainable-computing-io/kepler-helm-chart)
+![GitHub](https://img.shields.io/github/license/sustainable-computing-io/kepler-helm-chart) ![Release Charts](https://github.com/sustainable-computing-io/kepler-helm-chart/workflows/Release%20Charts/badge.svg?branch=main) [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/kepler)](https://artifacthub.io/packages/search?repo=kepler) [![Releases downloads](https://img.shields.io/github/downloads/sustainable-computing-io/kepler-helm-chart/total.svg)](https://github.com/sustainable-computing-io/kepler-helm-chart/releases)
 # kepler-helm-chart
 
 This repository is for the Helm chart for Kepler.  We are using `gh-pages` branch to host and index the chart.  When modifying the chart please bump the version in the [Chart.yaml](/chart/kepler/Chart.yaml) file.
+
+[Helm](https://helm.sh) must be installed to use the charts.
+Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
 
 The chart is accessible using the following commands:
 

--- a/chart/kepler/Chart.yaml
+++ b/chart/kepler/Chart.yaml
@@ -19,6 +19,6 @@ annotations:
   artifacthub.io/license: "Apache-2.0"
 
 type: application
-version: 0.3.7
+version: 0.3.8
 appVersion: v0.4.11-23-g2b59dbd-linux-amd64
 

--- a/chart/kepler/Chart.yaml
+++ b/chart/kepler/Chart.yaml
@@ -17,6 +17,9 @@ annotations:
     - name: docs
       url: https://sustainable-computing.io/
   artifacthub.io/license: "Apache-2.0"
+  artifacthub.io/signKey: |
+    fingerprint: 91BF31657FB6BB5931CBFCF92A544B84946E3621
+    url: https://keybase.io/bradmccoydev/pgp_keys.asc 
 
 type: application
 version: 0.3.8

--- a/cr.yaml
+++ b/cr.yaml
@@ -1,0 +1,5 @@
+# cr.yaml
+# Set to true for GPG signing
+sign: true
+# UID of the GPG key to use
+key: Brad McCoy


### PR DESCRIPTION
This will add the signing capability for the helm chart. This is important as folks can now verify the chart has not been tampered with because we add our signature to it, using our GPG key.

This will not change anything for people that don't want to verify as it will work normally.  In the release artifact, there will now be a .prov file with the signature.

We will need to add the following secrets to the repo before merging:
HELM_SIGNING_PRIVATE_KEY:
HELM_SIGNING_PRIVATE_KEY_PASSPHRASE: