### PR TITLE
Add podLabels

### DIFF
--- a/chart/kepler/Chart.yaml
+++ b/chart/kepler/Chart.yaml
@@ -22,6 +22,6 @@ annotations:
     url: https://keybase.io/bradmccoydev/pgp_keys.asc 
 
 type: application
-version: 0.3.8
+version: 0.3.9
 appVersion: v0.4.11-23-g2b59dbd-linux-amd64
 

--- a/chart/kepler/templates/daemonset.yaml
+++ b/chart/kepler/templates/daemonset.yaml
@@ -21,6 +21,9 @@ spec:
       {{- end }}
       labels:
         {{- include "kepler.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- . | toYaml | nindent 8 }}
+        {{- end }}
     spec:
       hostNetwork: true
       serviceAccountName: {{ include "kepler.serviceAccountName" . }}

--- a/chart/kepler/values.yaml
+++ b/chart/kepler/values.yaml
@@ -21,6 +21,9 @@ annotations: {}
 # -- Additional pod annotations
 podAnnotations: {}
 
+# -- Additional pod labels
+podLabels: {}
+
 # -- Privileges and access control settings for a Pod (all containers in a pod)
 podSecurityContext: {}
   # fsGroup: 2000


### PR DESCRIPTION
Hello! 👋🏻 

Some environments often enforce labeling policies that don't allow to run workloads without certain mandatory labels.
This PR adds the ability to configure additional labels in the chart values for the pod template spec of the daemonset.
