### PR TITLE
Tolerate new control-plane labels

### DIFF
--- a/chart/kepler/Chart.yaml
+++ b/chart/kepler/Chart.yaml
@@ -22,6 +22,6 @@ annotations:
     url: https://keybase.io/bradmccoydev/pgp_keys.asc 
 
 type: application
-version: 0.3.9
+version: 0.3.10
 appVersion: v0.4.11-23-g2b59dbd-linux-amd64
 

--- a/chart/kepler/values.yaml
+++ b/chart/kepler/values.yaml
@@ -38,7 +38,7 @@ nodeSelector: {}
 # -- Toleration for taints
 tolerations:
   - effect: NoSchedule
-    key: node-role.kubernetes.io/master
+    key: node-role.kubernetes.io/control-plane
 
 # -- Affinity rules
 affinity: {}

--- a/chart/kepler/values.yaml
+++ b/chart/kepler/values.yaml
@@ -33,7 +33,8 @@ securityContext:
   privileged: true
 
 # -- Node selection constraint
-nodeSelector: {}
+nodeSelector:
+  kubernetes.io/os: linux
 
 # -- Toleration for taints
 tolerations:


### PR DESCRIPTION
The `node-role.kubernetes.io/master` setting is going away in favor of `node-role.kubernetes.io/control-plane`