### PR TITLE
eBPF is linux only

### DIFF
--- a/chart/kepler/values.yaml
+++ b/chart/kepler/values.yaml
@@ -33,7 +33,8 @@ securityContext:
   privileged: true
 
 # -- Node selection constraint
-nodeSelector: {}
+nodeSelector:
+  kubernetes.io/os: linux
 
 # -- Toleration for taints
 tolerations:


### PR DESCRIPTION
This should avoid trying to setup kepler on non-linux nodes.