### PR TITLE
 kepler(0.4.1): do not set default `resources`

### DIFF
--- a/chart/kepler/Chart.yaml
+++ b/chart/kepler/Chart.yaml
@@ -22,5 +22,5 @@ annotations:
     url: https://keybase.io/bradmccoydev/pgp_keys.asc 
 
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: release-0.5

--- a/chart/kepler/values.yaml
+++ b/chart/kepler/values.yaml
@@ -45,13 +45,7 @@ tolerations:
 affinity: {}
 
 # -- CPU/MEM resources
-resources:
-  requests:
-    cpu: 100m
-    memory: 200Mi
-  limits:
-    cpu: 100m
-    memory: 200Mi
+resources: {}
 
 # -- Extra environment variables
 extraEnvVars:


### PR DESCRIPTION
Hi,
this PR removes the default `resources` values.

Better to let the user set these values based on their own environment.

Thanks 