### PR TITLE
explicitly set namespaces on objects

### DIFF
--- a/chart/kepler/Chart.yaml
+++ b/chart/kepler/Chart.yaml
@@ -22,5 +22,5 @@ annotations:
     url: https://keybase.io/bradmccoydev/pgp_keys.asc 
 
 type: application
-version: 0.4.3
+version: 0.4.4
 appVersion: release-0.5.1

--- a/chart/kepler/templates/daemonset.yaml
+++ b/chart/kepler/templates/daemonset.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ include "kepler.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kepler.labels" . | nindent 4 }}
   {{- with .Values.annotations }}

--- a/chart/kepler/templates/service.yaml
+++ b/chart/kepler/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kepler.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kepler.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}

--- a/chart/kepler/templates/serviceaccount.yaml
+++ b/chart/kepler/templates/serviceaccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kepler.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kepler.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/chart/kepler/templates/servicemonitor.yaml
+++ b/chart/kepler/templates/servicemonitor.yaml
@@ -6,6 +6,8 @@ metadata:
   name: {{ template "kepler.fullname" . }}-prometheus-exporter
   {{- if .Values.serviceMonitor.namespace }}
   namespace: {{ . }}
+  {{- else }}
+  namespace: {{ .Release.Namespace }}
   {{- end }}
   labels:
     {{- include "kepler.labels" . | nindent 4 }}


### PR DESCRIPTION
My linting checks noted that the namespaces are inferred rather than set explicitly in the helm templates.

This causes some confusion for gitops folks who render helm locally and commit the results to deploy directly.