### PR TITLE
kepler(0.5.3): bump to release-0.6.1

### DIFF
--- a/chart/kepler/Chart.yaml
+++ b/chart/kepler/Chart.yaml
@@ -22,5 +22,5 @@ annotations:
     url: https://keybase.io/bradmccoydev/pgp_keys.asc 
 
 type: application
-version: 0.5.2
-appVersion: release-0.5.5
+version: 0.5.3
+appVersion: release-0.6.1

--- a/chart/kepler/templates/daemonset.yaml
+++ b/chart/kepler/templates/daemonset.yaml
@@ -28,8 +28,10 @@ spec:
     spec:
       hostNetwork: true
       serviceAccountName: {{ include "kepler.serviceAccountName" . }}
-      imagePullSecrets: 
-          {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: kepler-exporter
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
Bump to release-0.6.1.

Closes https://github.com/sustainable-computing-io/kepler-helm-chart/issues/51