### PR TITLE
Add relabelings for ServiceMonitor

### DIFF
--- a/chart/kepler/templates/servicemonitor.yaml
+++ b/chart/kepler/templates/servicemonitor.yaml
@@ -22,13 +22,10 @@ spec:
       {{- end }}
       path: /metrics
       scheme: http
+      {{- with .Values.serviceMonitor.relabelings }}
       relabelings:
-        - action: replace
-          regex: (.*)
-          replacement: $1
-          sourceLabels:
-            - __meta_kubernetes_pod_node_name
-          targetLabel: instance
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/chart/kepler/values.yaml
+++ b/chart/kepler/values.yaml
@@ -83,6 +83,13 @@ serviceMonitor:
   interval: 30s
   scrapeTimeout: 5s
   labels: {}
+  relabelings:
+    - action: replace
+      regex: (.*)
+      replacement: $1
+      sourceLabels:
+        - __meta_kubernetes_pod_node_name
+      targetLabel: instance
 
 redfish:
   enabled: false


### PR DESCRIPTION
I'd like to configure relabelings in `ServiceMonitor` of Kepler.