### PR TITLE
kepler(0.5.9): fix different name between ClusterRole refs

### DIFF
--- a/chart/kepler/Chart.yaml
+++ b/chart/kepler/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kepler
-description: A Helm chart for kepler (Kubernetes-based Efficient Power Level Exporter) 
+description: A Helm chart for kepler (Kubernetes-based Efficient Power Level Exporter)
 icon: "https://avatars.githubusercontent.com/u/91567619?s=200&v=4"
 home: https://sustainable-computing.io/html/index.html
 sources:
@@ -19,8 +19,8 @@ annotations:
   artifacthub.io/license: "Apache-2.0"
   artifacthub.io/signKey: |
     fingerprint: 91BF31657FB6BB5931CBFCF92A544B84946E3621
-    url: https://keybase.io/bradmccoydev/pgp_keys.asc 
+    url: https://keybase.io/bradmccoydev/pgp_keys.asc
 
 type: application
-version: 0.5.8
+version: 0.5.9
 appVersion: release-0.7.11

--- a/chart/kepler/templates/rolebinding.yaml
+++ b/chart/kepler/templates/rolebinding.yaml
@@ -22,7 +22,7 @@ metadata:
   name: {{ include "kepler.name" . }}-clusterrole-binding
 roleRef:
   kind: ClusterRole
-  name: {{ .Chart.Name }}-clusterrole
+  name: {{ include "kepler.name" . }}-clusterrole
   apiGroup: "rbac.authorization.k8s.io"
 subjects:
   - kind: ServiceAccount


### PR DESCRIPTION
Fix: https://github.com/sustainable-computing-io/kepler-helm-chart/issues/64

`ClusterRole` and `ClusterRoleBinding/ClusterRole` uses a different name template, unify to `{{ include "kepler.name" . }}-clusterrole`