### PR TITLE
 kepler(0.5.9): fix different name between ClusterRole refs

### DIFF
--- a/chart/kepler/Chart.yaml
+++ b/chart/kepler/Chart.yaml
@@ -22,5 +22,5 @@ annotations:
     url: https://keybase.io/bradmccoydev/pgp_keys.asc 
 
 type: application
-version: 0.5.8
+version: 0.5.9
 appVersion: release-0.7.11

--- a/chart/kepler/templates/rolebinding.yaml
+++ b/chart/kepler/templates/rolebinding.yaml
@@ -22,7 +22,7 @@ metadata:
   name: {{ include "kepler.name" . }}-clusterrole-binding
 roleRef:
   kind: ClusterRole
-  name: {{ .Chart.Name }}-clusterrole
+  name: {{ include "kepler.name" . }}-clusterrole
   apiGroup: "rbac.authorization.k8s.io"
 subjects:
   - kind: ServiceAccount


### PR DESCRIPTION
Fix: https://github.com/sustainable-computing-io/kepler-helm-chart/issues/64

`ClusterRole` and `ClusterRoleBinding/ClusterRole` uses a different name template, unify to `{{ include "kepler.name" . }}-clusterrole`