### PR TITLE
make rbac configurable

### DIFF
--- a/chart/kepler/Chart.yaml
+++ b/chart/kepler/Chart.yaml
@@ -22,5 +22,5 @@ annotations:
     url: https://keybase.io/bradmccoydev/pgp_keys.asc
 
 type: application
-version: 0.5.11
+version: 0.5.12
 appVersion: release-0.7.12

--- a/chart/kepler/templates/rolebinding.yaml
+++ b/chart/kepler/templates/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -28,3 +29,4 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "kepler.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/chart/kepler/values.yaml
+++ b/chart/kepler/values.yaml
@@ -72,6 +72,11 @@ service:
   type: ClusterIP
   port: 9102
 
+
+rbac:
+  # Specifies whether rbac should be created
+  create: true
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
We use RBAC management on our platform in another way, so it would be a good option to make this configurable.