### PR TITLE
Add Pod Security Context in Template to match values.yaml

### DIFF
--- a/chart/kepler/Chart.yaml
+++ b/chart/kepler/Chart.yaml
@@ -22,5 +22,5 @@ annotations:
     url: https://keybase.io/bradmccoydev/pgp_keys.asc
 
 type: application
-version: 0.5.12
+version: 0.5.13
 appVersion: release-0.7.12

--- a/chart/kepler/templates/daemonset.yaml
+++ b/chart/kepler/templates/daemonset.yaml
@@ -118,6 +118,10 @@ spec:
           secret:
             secretName: {{ .Values.redfish.name }}
         {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
Currently in the [values.yaml](https://github.com/sustainable-computing-io/kepler-helm-chart/blob/main/chart/kepler/values.yaml#L28) there's an option to add security context for the pod, but isn't in the Daemonset template. This is to allow for it being set correctly.