### PR TITLE
metricRelabelings

### DIFF
--- a/chart/kepler/Chart.yaml
+++ b/chart/kepler/Chart.yaml
@@ -22,5 +22,5 @@ annotations:
     url: https://keybase.io/bradmccoydev/pgp_keys.asc
 
 type: application
-version: 0.5.18
+version: 0.5.19
 appVersion: release-0.8.0

--- a/chart/kepler/templates/servicemonitor.yaml
+++ b/chart/kepler/templates/servicemonitor.yaml
@@ -30,6 +30,10 @@ spec:
       relabelings:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/chart/kepler/values.yaml
+++ b/chart/kepler/values.yaml
@@ -101,6 +101,18 @@ serviceMonitor:
       sourceLabels:
         - __meta_kubernetes_pod_node_name
       targetLabel: instance
+  metricRelabelings: []
+    ## For example when you need the name of the pod's namespace in the 'namespace' label, e.g. for a multitenant setup
+    # - action: replace
+    #   regex: (.*)
+    #   sourceLabels:
+    #   - namespace
+    #   targetLabel: app_namespace
+    # - action: replace
+    #   regex: (.*)
+    #   sourceLabels:
+    #   - container_namespace
+    #   targetLabel: namespace
 
 redfish:
   enabled: false


### PR DESCRIPTION
For our multi-tenancy setup it is important that the value of 'container_namespace' is in a label called 'namespace'. Moving that value does not work with 'relabelings', it only works with 'metricRelabelings'.